### PR TITLE
loppers special forms permits case

### DIFF
--- a/lib/loppers.ex
+++ b/lib/loppers.ex
@@ -132,6 +132,7 @@ defmodule Loppers do
     special_forms ++ [
       :{},
       :doc,
+      :->,
       {Kernel, :is_binary}
     ]
   end

--- a/test/examples/case.ex
+++ b/test/examples/case.ex
@@ -1,0 +1,11 @@
+defmodule Case do
+  # make sure special forms has ->
+  def speak(animal) do
+    case animal do
+      :cat -> 
+        "meow"
+      :dog -> 
+        "arf"
+    end
+  end
+end

--- a/test/walk_tree_test.exs
+++ b/test/walk_tree_test.exs
@@ -113,6 +113,12 @@ defmodule LoppersTest.Walk do
 
     test_allow("defdo.ex", whitelist)
   end
+  
+  test "case and -> special form" do
+    whitelist = @whitelist ++ Loppers.special_forms()
+    
+    test_allow("case.ex", whitelist)
+  end
 
   def get_file(file) do
     file = "#{@examples}#{file}"


### PR DESCRIPTION
*Problem:* Before this commit, `case` is in special forms, but `->` is not. The result is that Loppers does not permit cases.

*Solution:* Add `->` to special forms and write test confirming that a whitelist with Loppers.special_forms/1 permits a `case`. 